### PR TITLE
fix(eslint): ignore the mock folder

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,6 +17,7 @@ module.exports = {
     'no-console': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
     'no-debugger': process.env.NODE_ENV === 'production' ? 'warn' : 'off'
   },
+  ignorePatterns: ['src/mocks/**'],
   overrides: [
     {
       files: ['**/__tests__/*.{j,t}s?(x)', '**/tests/unit/**/*.spec.{j,t}s?(x)'],

--- a/src/mocks/apiDataMock.ts
+++ b/src/mocks/apiDataMock.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { ApiData } from '@molgenis/vip-report-api';
 
 export const apiData: ApiData = {


### PR DESCRIPTION
Eslint shouldn't complain about our mockdata, that's rude, it's perfect just the way it is. 